### PR TITLE
Run UTs with coverage

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -67,7 +67,7 @@ class SNMPExporterCharm(ops.CharmBase):
             # The actual SNMP scrape jobs
             {
                 "job_name": "snmp",
-                "static_configs": [{"targets": self.model.config["targets"].split(",")}],
+                "static_configs": [{"targets": str(self.model.config["targets"]).split(",")}],
                 "metrics_path": "/snmp",
                 "params": {
                     "auth": ["public_v2"],

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -1,20 +1,21 @@
 import json
 
-import charm
 from scenario import Context, Relation, State
+
+import charm
 
 
 def test_status_no_config():
     context = Context(charm_type=charm.SNMPExporterCharm)
     state = State(config={"targets": ""})
-    state_out = context.run(event="config-changed", state=state)
+    state_out = context.run(context.on.config_changed(), state=state)
     assert state_out.unit_status.name == "blocked"
 
 
 def test_status_with_config():
     context = Context(charm_type=charm.SNMPExporterCharm)
     state = State(config={"targets": "1.2.3.4"})
-    state_out = context.run(event="config-changed", state=state)
+    state_out = context.run(context.on.config_changed(), state=state)
     assert state_out.unit_status.name == "active"
 
 
@@ -22,7 +23,9 @@ def test_cos_agent_relation_data_is_set():
     cos_agent_relation = Relation("cos-agent", remote_app_name="grafana-agent")
     context = Context(charm_type=charm.SNMPExporterCharm)
     state = State(relations=[cos_agent_relation], config={"targets": "1.2.3.4"})
-    state_out = context.run(event=cos_agent_relation.changed_event, state=state)
+    state_out = context.run(context.on.relation_changed(cos_agent_relation), state=state)
 
-    relation_data = json.loads(state_out.relations[0].local_unit_data["config"])
+    relation_data = json.loads(
+        state_out.get_relation(cos_agent_relation.id).local_unit_data["config"]
+    )
     assert len(relation_data["metrics_scrape_jobs"]) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     ruff
 commands =
     black {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -39,12 +39,21 @@ deps =
     codespell
 commands =
     codespell {toxinidir}
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-[testenv:unit]
+[testenv:{unit,scenario}]
 description = Run unit tests
-commands = :
+deps = 
+    pytest
+    ops[testing]
+    coverage[toml]
+    deepdiff
+    -r{toxinidir}/requirements.txt
+commands = 
+    coverage run --source={[vars]src_path} \
+        -m pytest  -v --tb native -s {posargs} {[vars]tests_path}/scenario
+    coverage report
 
 [testenv:static-charm]
 description = Run static type checks
@@ -58,14 +67,6 @@ commands =
 description = Run static type checks for libs
 commands = :
 
-[testenv:scenario]
-description = Run scenario tests
-deps = 
-    pytest
-    ops-scenario
-    -r requirements.txt
-commands = 
-    pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/scenario
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
## Issue
TICS scan [fails](https://github.com/canonical/snmp-exporter-operator/actions/runs/14161419656/job/39667434070) due to missing UTs run coverage 

## Solution
Run unit tests with coverage.

## Drive-bys
- Fix `ruff` commands for `fmt` and `lint`

